### PR TITLE
feat(deploy): kubernetes deployment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,7 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false
 insert_final_newline = false
+
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+description: Pastebin IPFS
+kubeVersion: '>=1.16.0-0'
+maintainers:
+  - name: Mayo Cream
+    email: i@shoujo.io
+name: pastebin-ipfs
+sources:
+- https://github.com/mayocream/pastebin-ipfs
+version: 0.1

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: pastebin-ipfs
+  name: pastebin-ipfs
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: pastebin-ipfs
+  template:
+    metadata:
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '3939'
+        prometheus.io/path: '/metrics'
+      labels:
+        app: pastebin-ipfs
+    spec:
+      containers:
+      - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        name: pastebin-ipfs
+        ports:
+          - name: web
+            containerPort: 3939
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        command: {{- toYaml .Values.command | nindent 8 }}
+      - image: ipfs/go-ipfs:v0.10.0
+        name: ipfs-daemon
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+          

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+  labels:
+    app: pastebin-ipfs
+  name: pastebin-ipfs
+spec:
+  rules:
+  - host: {{ .Values.ingress.host }}
+    http:
+      paths:
+      - path: / 
+        backend:
+          serviceName: pastebin-ipfs
+          servicePort: 3939
+  tls:
+  - hosts:
+    - {{ .Values.ingress.host }}
+    secretName: {{ .Values.ingress.secretName }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: pastebin-ipfs
+  name: pastebin-ipfs
+spec:
+  ports:
+  - name: web
+    port: 3939
+    targetPort: 3939
+  selector:
+    app: pastebin-ipfs

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,27 @@
+replicas: 2
+
+image:
+  repository: mayocream/pastebin-ipfs
+  tag: latest
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 50Mi
+  limits:
+    cpu: 1
+    memory: 2G
+
+command:
+  - pstbin
+  - -ipfs
+  - 127.0.0.1:5001
+
+ingress:
+  host: paste.yourcomany.com
+  secretName: pastebin-ipfs-host
+  annotations:
+    # cert-manager.io/cluster-issuer: default
+    kubernetes.io/ingress.class: nginx
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"


### PR DESCRIPTION
```yaml
$ helm template .
---
# Source: pastebin-ipfs/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app: pastebin-ipfs
  name: pastebin-ipfs
spec:
  ports:
  - name: web
    port: 3939
    targetPort: 3939
  selector:
    app: pastebin-ipfs
---
# Source: pastebin-ipfs/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: pastebin-ipfs
  name: pastebin-ipfs
spec:
  replicas: 2
  selector:
    matchLabels:
      app: pastebin-ipfs
  template:
    metadata:
      annotations:
        prometheus.io/scrape: 'true'
        prometheus.io/port: '3939'
        prometheus.io/path: '/metrics'
      labels:
        app: pastebin-ipfs
    spec:
      containers:
      - image: mayocream/pastebin-ipfs:latest
        name: pastebin-ipfs
        ports:
          - name: web
            containerPort: 3939
        resources:
          limits:
            cpu: 1
            memory: 2G
          requests:
            cpu: 50m
            memory: 50Mi
        command:
        - pstbin
        - -ipfs
        - 127.0.0.1:5001
      - image: ipfs/go-ipfs:v0.10.0
        name: ipfs-daemon
        resources:
          limits:
            cpu: 1
            memory: 2G
          requests:
            cpu: 50m
            memory: 50Mi
---
# Source: pastebin-ipfs/templates/ingress.yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  annotations:
    kubernetes.io/ingress.class: nginx
    kubernetes.io/tls-acme: "true"
    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
  labels:
    app: pastebin-ipfs
  name: pastebin-ipfs
spec:
  rules:
  - host: paste.yourcomany.com
    http:
      paths:
      - path: / 
        backend:
          serviceName: pastebin-ipfs
          servicePort: 3939
  tls:
  - hosts:
    - paste.yourcomany.com
    secretName: pastebin-ipfs-host
```

```bash
$ helm template . | k apply --dry-run=client -f - 
service/pastebin-ipfs created (dry run)
deployment.apps/pastebin-ipfs created (dry run)
ingress.extensions/pastebin-ipfs created (dry run)
```